### PR TITLE
Fix debugger so it can actually be used

### DIFF
--- a/src/Debugger.php
+++ b/src/Debugger.php
@@ -72,7 +72,7 @@ class Debugger {
                 $string .= "\n";
             }
 
-            $date = new DateTime();
+            $date = new \DateTime();
             $string = '['.$date->format('Y-m-d H:i:s.u').'] '.$string;
 
             if (static::$log_file) {


### PR DESCRIPTION
The reference to PHP's built-in DateTime class was missing the leading
namespace separator, causing a fatal error due to the class supposedly
not existing.
