### PR TITLE
Allow custom BBCodeLibrary class to be passed in

### DIFF
--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -224,9 +224,11 @@ class BBCode {
 
     /**
      * Initialize a new instance of the {@link BBCode} class.
+     *
+     * @param BBCodeLibrary|null $library
      */
-    public function __construct() {
-        $this->defaults = new BBCodeLibrary();
+    public function __construct(BBCodeLibrary $library = null) {
+        $this->defaults = isset($library) ? $library : new BBCodeLibrary();
         $this->tag_rules = $this->defaults->default_tag_rules;
         $this->smileys = $this->defaults->default_smileys;
         $this->enable_smileys = true;


### PR DESCRIPTION
This lets you pass in your own subclass of BBCodeLibrary with possibly
different defaults and have those used automatically by the BBCode
class. This avoids the need to subclass the BBCode class as well in
order to perform additional work to make this possible.