### PR TITLE
Ensure isValidURL method always returns a boolean

### DIFF
--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -813,6 +813,8 @@ class BBCode {
         if ($email_too && substr($string, 0, 7) == "mailto:") {
             return $this->isValidEmail(substr($string, 7));
         }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Previously under some circumstances, isValidURL() could return null
instead of a boolean. Now, it will always return a boolean.