### PR TITLE
Fix continue usage in switch of BBCodeLexer

### DIFF
--- a/src/BBCodeLexer.php
+++ b/src/BBCodeLexer.php
@@ -325,7 +325,7 @@ class BBCodeLexer {
                             if (strlen($this->text) > 0) {
                                 return $this->token = BBCode::BBCODE_TEXT;
                             }
-                            continue;
+                            break;
                         }
                         break;
                     default:


### PR DESCRIPTION
PHP's switch statements recognize the `continue` keyword and treat it as a `break`. Using a `continue` inside a switch, inside of a loop, a developer might expect execution to bail out of the switch and return to the top of the loop. This would not be the case. As of PHP 7.3, usage of a `continue` in a switch statement will result in a warning and a recommendation to use either `break` or `continue 2`.

This update replaces a `continue` in a switch inside `BBCodeLexer` with a `break`. I am replacing with a `break`, instead of a `continue 2`, because it should remain functionally identical to its current state.