### PR TITLE
Fix deprecation warnings in PHP 8.1

### DIFF
--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -1595,12 +1595,12 @@ REGEX;
         // to the start tag itself.)
         if (isset($this->tag_rules[$tag_name]) && isset($this->tag_rules[$tag_name]['after_tag'])) {
             $newpos = $this->cleanupWSByIteratingPointer(
-                isset($this->tag_rules[$tag_name]['after_tag']) ? $this->tag_rules[$tag_name]['after_tag'] : null,
+                $this->tag_rules[$tag_name]['after_tag'],
                 $pos + 1,
                 $this->stack
             );
         } else {
-            $newpos = $this->cleanupWSByIteratingPointer(null, $pos + 1, $this->stack);
+            $newpos = $pos + 1;
         }
         $delta = $newpos - ($pos + 1);
 
@@ -1619,7 +1619,7 @@ REGEX;
         if (isset($this->tag_rules[$tag_name]) && isset($this->tag_rules[$tag_name]['before_endtag'])) {
             $newend = $this->cleanupWSByIteratingPointer($this->tag_rules[$tag_name]['before_endtag'], 0, $output);
         } else {
-            $newend = $this->cleanupWSByIteratingPointer(null, 0, $output);
+            $newend = 0;
         }
         $output = $this->collectTextReverse($output, count($output) - 1, $newend);
 
@@ -2146,9 +2146,13 @@ REGEX;
             return;
         }
 
-        $this->cleanupWSByPoppingStack($tag_rule['before_tag'], $this->stack);
+        if (isset($tag_rule['before_tag'])) {
+            $this->cleanupWSByPoppingStack($tag_rule['before_tag'], $this->stack);
+        }
         $output = $this->doTag(self::BBCODE_OUTPUT, $tag_name, $tag_params['_default'], $tag_params, "");
-        $this->cleanupWSByEatingInput($tag_rule['after_tag']);
+        if (isset($tag_rule['after_tag'])) {
+            $this->cleanupWSByEatingInput($tag_rule['after_tag']);
+        }
 
         if ($this->debug) {
             Debugger::debug("<b>ProcessIsolatedTag:</b> isolated tag <tt>[".htmlspecialchars($tag_name)
@@ -2257,17 +2261,13 @@ REGEX;
         if (isset($tag_rule['after_tag'])) {
             $newstart = $this->cleanupWSByIteratingPointer($tag_rule['after_tag'], $start, $this->stack);
         } else {
-            $newstart = $this->cleanupWSByIteratingPointer(null, $start, $this->stack);
+            $newstart = $start;
         }
         if (isset($tag_rule['before_endtag'])) {
             $this->cleanupWSByPoppingStack($tag_rule['before_endtag'], $this->stack);
-        } else {
-            $this->cleanupWSByPoppingStack(null, $this->stack);
         }
         if (isset($tag_rule['after_endtag'])) {
             $this->cleanupWSByEatingInput($tag_rule['after_endtag']);
-        } else {
-            $this->cleanupWSByEatingInput(null);
         }
 
         // Collect the output from $newstart to the top of the stack, and then
@@ -2284,8 +2284,6 @@ REGEX;
         // onto the stack itself, so we don't need to remove it).
         if (isset($tag_rule['before_tag'])) {
             $this->cleanupWSByPoppingStack($tag_rule['before_tag'], $this->stack);
-        } else {
-            $this->cleanupWSByPoppingStack(null, $this->stack);
         }
 
         // Found the end tag, so process this tag immediately with
@@ -2512,8 +2510,6 @@ REGEX;
 
         if (isset($this->tag_rules[$tag_name]) && isset($this->tag_rules[$tag_name]['before_tag'])) {
             $this->cleanupWSByPoppingStack($this->tag_rules[$tag_name]['before_tag'], $this->stack);
-        } else {
-            $this->cleanupWSByPoppingStack(null, $this->stack);
         }
         $start_tag_params['_endtag'] = $tag_params['_tag'];
         $start_tag_params['_hasend'] = true;
@@ -2527,8 +2523,6 @@ REGEX;
 
         if (isset($this->tag_rules[$tag_name]['after_endtag'])) {
             $this->cleanupWSByEatingInput($this->tag_rules[$tag_name]['after_endtag']);
-        } else {
-            $this->cleanupWSByEatingInput(null);
         }
 
         if ($this->debug) {


### PR DESCRIPTION
According to the PHP 8.1 changelog:

> Passing null to non-nullable internal function parameters is
> deprecated.

There are a handful of places in BBCode.php that pass null to the
`strlen` function, which results in the following warnings:

> Deprecated: strlen(): Passing null to parameter #1 ($string) of
> type string is deprecated

This affects 3 functions:

1) cleanupWSByPoppingStack
2) cleanupWSByEatingInput
3) cleanupWSByIteratingPointer

In the cases of 1) and 2), passing `$pattern = null` is a no-op, and
therefore we can safely omit these calls entirely. This is because we
immediately trigger the condition:

    if (strlen($pattern) <= 0)
        return;

In the case of 3), passing `$pattern = null` returns the 2nd argument
passed to the function, so we can simply use this value directly
instead. This is because we immediately trigger the condition:

    if (strlen($pattern) <= 0)
        return $pos;

These changes should fix the deprecation warnings, because we will no
longer pass null to `strlen`, while also leaving the logic unchanged.