### PR TITLE
Fix [list] element in PHP 8.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,6 @@ workflows:
       - php_74_tests:
           requires:
             - php_setup
-#      - php_80_tests:
-#          requires:
-#            - php_setup
+      - php_80_tests:
+          requires:
+            - php_setup

--- a/src/BBCodeLibrary.php
+++ b/src/BBCodeLibrary.php
@@ -808,7 +808,7 @@ class BBCodeLibrary {
         $default = trim($default);
 
         if ($action == BBCode::BBCODE_CHECK) {
-            if (!is_string($default) || strlen($default) == "") {
+            if (!is_string($default) || strlen($default) == 0) {
                 return true;
             } elseif (isset($listStyles[$default])) {
                 return true;
@@ -820,7 +820,7 @@ class BBCodeLibrary {
         }
 
         // Choose a list element (<ul> or <ol>) and a style.
-        if (!is_string($default) || strlen($default) == "") {
+        if (!is_string($default) || strlen($default) == 0) {
             $elem = 'ul';
             $type = '';
         } elseif ($default == '1') {


### PR DESCRIPTION
The BBCodeLibrary::doList function was affected by a change to how
string to number comparison works in PHP 8.0.

In PHP 7.4 and earlier:

    0 == "foo"  // evalulates to true

In PHP 8.0+:

    0 == "foo"  // evaluates to false

See the RFC at https://wiki.php.net/rfc/string_to_number_comparison.

We fix this by changing:

    strlen($default) == ""

to:

    strlen($default) == 0

as the output of `strlen` is always an int and should not be compared
to a string.

The PHP 8.0 test is re-enabled in Circle CI.