### PR TITLE
Update to next-gen CircleCI docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ aliases:
 jobs:
   php_setup:
     docker:
-      - image: 'circleci/php:7.2.34-cli'
+      - image: 'cimg/php:7.2'
     steps:
       - core/checkout
       # We explcitly don't cache dependencies.
@@ -26,7 +26,7 @@ jobs:
             - repo
   php_72_tests:
     docker:
-      - image: 'circleci/php:7.2.34-cli'
+      - image: 'cimg/php:7.2'
     steps: &php_unit_test_steps
       - *attach_workspace
       - run:
@@ -41,15 +41,15 @@ jobs:
             ./vendor/bin/phpunit -c ./tests/phpunit.xml.dist
   php_73_tests:
     docker:
-      - image: 'circleci/php:7.3.33-cli'
+      - image: 'cimg/php:7.3'
     steps: *php_unit_test_steps
   php_74_tests:
     docker:
-      - image: 'circleci/php:7.4.27-cli'
+      - image: 'cimg/php:7.4'
     steps: *php_unit_test_steps
   php_80_tests:
     docker:
-      - image: 'circleci/php:8.0.12-cli'
+      - image: 'cimg/php:8.0'
     steps: *php_unit_test_steps
 workflows:
   version: 2


### PR DESCRIPTION
The `circleci` docker namespace has been retired in favor of the `cimg`
namespace, as part of a major update to CircleCI docker infrastructure.

See:
  https://circleci.com/docs/2.0/next-gen-migration-guide/
  https://circleci.com/developer/images/image/cimg/php

New PHP versions (such as the PHP 8.1 image) will only be available in
this new namespace.