### PR TITLE
Fix remaining deprecation warnings in PHP 8.1

### DIFF
--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -3,6 +3,7 @@
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
+         convertDeprecationsToExceptions="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"


### PR DESCRIPTION
This is a followup to #24 that fixes all remaining deprecated calls in
PHP 8.1 that occur during execution of the unit tests. Deprecations are
converted to exceptions to make the tests more strict (as in #27, for
warnings and notices).

The primary cause of these deprecation warnings is passing a `null`
pattern to any of the `cleanupWS*` functions, which then pass it to
`strlen`. In PHP 8.1, passing null to non-nullable internal functions
is deprecated.

In https://github.com/vanilla/nbbc/pull/24#issuecomment-1006023802, we
got some insight into the intended design of the `cleanupWS*` functions
from @seanofw, the original author of this package. With the use of the
PHP 7 null coalescing operator, we can respect the intended design by
_always_ calling the `cleanupWS*` functions, e.g.:

```php
    $newpos = $this->cleanupWSByIteratingPointer(
        $this->tag_rules[$tag_name]['after_tag'] ?? '',
        $pos + 1,
        $this->stack
    );
```

instead of:

```php
    if (isset($this->tag_rules[$tag_name]['after_tag'])) {
        $newpos = $this->cleanupWSByIteratingPointer(
            $this->tag_rules[$tag_name]['after_tag'],
            $pos + 1,
            $this->stack
        );
    } else {
        $newpos = $pos + 1;
    }
```

That is, if the pattern is not defined or is null, we pass the empty
string as the pattern instead, since all `cleanupWS*` functions return
early if the pattern is the empty string.