### PR TITLE
Convert single quotes when escaping HTML entities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,10 @@ jobs:
     docker:
       - image: 'circleci/php:8.0.12-cli'
     steps: *php_unit_test_steps
+  php_81_tests:
+    docker:
+      - image: 'cimg/php:8.1'
+    steps: *php_unit_test_steps
 workflows:
   version: 2
   commit:
@@ -66,5 +70,8 @@ workflows:
           requires:
             - php_setup
       - php_80_tests:
+          requires:
+            - php_setup
+      - php_81_tests:
           requires:
             - php_setup

--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -762,7 +762,7 @@ class BBCode {
     // and performs exactly the same function.  Unlike html_entity_decode, it
     // works on older versions of PHP (prior to 4.3.0).
     public function unHTMLEncode($string) {
-        return html_entity_decode($string);
+        return html_entity_decode($string, ENT_QUOTES);
     }
 
 
@@ -903,7 +903,7 @@ class BBCode {
     public function htmlEncode($string) {
         if ($this->escape_content) {
             if (!$this->allow_ampersand) {
-                return htmlspecialchars($string);
+                return htmlspecialchars($string, ENT_QUOTES);
             } else {
                 return str_replace(['<', '>', '"'], ['&lt;', '&gt;', '&quot;'], $string);
             }
@@ -995,9 +995,9 @@ class BBCode {
                         // For non-smiley text, we just pass it through htmlspecialchars.
                         $output .= $this->htmlEncode($token);
                     } else {
-                        $alt = htmlspecialchars($token);
+                        $alt = htmlspecialchars($token, ENT_QUOTES);
                         if ($smiley_count < $this->max_smileys || $this->max_smileys < 0) {
-                            $output .= "<img src=\"".htmlspecialchars($this->smiley_url.'/'.$this->smileys[$token]).'"'
+                            $output .= "<img src=\"".htmlspecialchars($this->smiley_url.'/'.$this->smileys[$token], ENT_QUOTES).'"'
 //								. "\" width=\"{$info[ 0 ]}\" height=\"{$info[ 1 ]}\""
                                 ." alt=\"$alt\" title=\"$alt\" class=\"bbcode_smiley\" />";
                         } else {
@@ -1310,7 +1310,7 @@ REGEX;
                     } elseif (isset($flags['k'])) {
                         $value = $this->wikify($value);
                     } elseif (isset($flags['h'])) {
-                        $value = htmlspecialchars($value);
+                        $value = htmlspecialchars($value, ENT_QUOTES);
                     } elseif (isset($flags['u'])) {
                         $value = urlencode($value);
                     }
@@ -1666,7 +1666,7 @@ REGEX;
 
             switch ($item[self::BBCODE_STACK_TOKEN]) {
                 case self::BBCODE_TEXT:
-                    $string .= "\"".htmlspecialchars($item[self::BBCODE_STACK_TEXT])."\" ";
+                    $string .= "\"".htmlspecialchars($item[self::BBCODE_STACK_TEXT], ENT_QUOTES)."\" ";
                     break;
                 case self::BBCODE_WS:
                     $string .= "WS ";
@@ -1675,7 +1675,7 @@ REGEX;
                     $string .= "NL ";
                     break;
                 case self::BBCODE_TAG:
-                    $string .= "[".htmlspecialchars($item[self::BBCODE_STACK_TAG]['_name'])."] ";
+                    $string .= "[".htmlspecialchars($item[self::BBCODE_STACK_TAG]['_name'], ENT_QUOTES)."] ";
                     break;
                 default:
                     $string .= "unknown ";
@@ -1861,7 +1861,7 @@ REGEX;
     //
     //   $params is an array of key => value parameters associated with the tag; for example,
     //        in [smiley src=smile alt=:-)], it's Array('src' => "smile", 'alt' => ":-)").
-    //        These keys and values have NOT beel passed through htmlspecialchars().
+    //        These keys and values have NOT been passed through htmlspecialchars().
     //
     //   $contents is the body of the tag during BBCODE_OUTPUT.  For example, in
     //        [b]Hello[/b], it's "Hello".  THIS VALUE IS ALWAYS HTML, not BBCode.
@@ -1978,7 +1978,7 @@ REGEX;
                             break;
                         }
                         if (isset($params[$possible_content]) && strlen($params[$possible_content]) > 0) {
-                            $result = htmlspecialchars($params[$possible_content]);
+                            $result = htmlspecialchars($params[$possible_content], ENT_QUOTES);
                             break;
                         }
                     }
@@ -2223,7 +2223,7 @@ REGEX;
 
             $this->stack[] = Array(
                 self::BBCODE_STACK_TOKEN => $token_type,
-                self::BBCODE_STACK_TEXT => htmlspecialchars($this->lexer->text),
+                self::BBCODE_STACK_TEXT => htmlspecialchars($this->lexer->text, ENT_QUOTES),
                 self::BBCODE_STACK_TAG => $this->lexer->tag,
                 self::BBCODE_STACK_CLASS => $this->current_class,
             );

--- a/src/BBCodeLibrary.php
+++ b/src/BBCodeLibrary.php
@@ -450,13 +450,13 @@ class BBCodeLibrary {
             }
 
             if ($bbcode->getURLTargetable() !== false && isset($params['target'])) {
-                $target = ' target="'.htmlspecialchars($params['target']).'"';
+                $target = ' target="'.htmlspecialchars($params['target'], ENT_QUOTES).'"';
             } else {
                 $target = '';
             }
 
             if ($bbcode->getURLTarget() !== false && empty($target)) {
-                $target = ' target="'.htmlspecialchars($bbcode->getURLTarget()).'"';
+                $target = ' target="'.htmlspecialchars($bbcode->getURLTarget(), ENT_QUOTES).'"';
             }
 
             // If $detect_urls is on, it's possble the $content is already
@@ -465,7 +465,7 @@ class BBCodeLibrary {
 
             return $bbcode->fillTemplate($bbcode->getURLTemplate(), array("url" => $url, "target" => $target, "content" => $content));
         } else {
-            return htmlspecialchars($params['_tag']).$content.htmlspecialchars($params['_endtag']);
+            return htmlspecialchars($params['_tag'], ENT_QUOTES).$content.htmlspecialchars($params['_endtag'], ENT_QUOTES);
         }
     }
 
@@ -498,7 +498,7 @@ class BBCodeLibrary {
         if ($bbcode->isValidEmail($email)) {
             return $bbcode->fillTemplate($bbcode->getEmailTemplate(), array("email" => $email, "content" => $content));
         } else {
-            return htmlspecialchars($params['_tag']).$content.htmlspecialchars($params['_endtag']);
+            return htmlspecialchars($params['_tag'], ENT_QUOTES).$content.htmlspecialchars($params['_endtag'], ENT_QUOTES);
         }
     }
 
@@ -662,16 +662,16 @@ class BBCodeLibrary {
                 $localImgURL = $bbcode->getLocalImgURL();
 
                 return "<img src=\""
-                .htmlspecialchars((empty($localImgURL) ? '' : $localImgURL.'/').ltrim($urlParts['path'], '/')).'" alt="'
-                .htmlspecialchars(basename($content)).'" class="bbcode_img" />';
+                .htmlspecialchars((empty($localImgURL) ? '' : $localImgURL.'/').ltrim($urlParts['path'], '/'), ENT_QUOTES).'" alt="'
+                .htmlspecialchars(basename($content), ENT_QUOTES).'" class="bbcode_img" />';
             } elseif ($bbcode->isValidURL($content, false)) {
                 // Remote URL, or at least we don't know where it is.
-                return '<img src="'.htmlspecialchars($content).'" alt="'
-                .htmlspecialchars(basename($content)).'" class="bbcode_img" />';
+                return '<img src="'.htmlspecialchars($content, ENT_QUOTES).'" alt="'
+                .htmlspecialchars(basename($content), ENT_QUOTES).'" class="bbcode_img" />';
             }
         }
 
-        return htmlspecialchars($params['_tag']).htmlspecialchars($content).htmlspecialchars($params['_endtag']);
+        return htmlspecialchars($params['_tag'], ENT_QUOTES).htmlspecialchars($content, ENT_QUOTES).htmlspecialchars($params['_endtag'], ENT_QUOTES);
     }
 
     /**
@@ -730,21 +730,21 @@ class BBCodeLibrary {
         }
 
         if (isset($params['name'])) {
-            $title = htmlspecialchars(trim($params['name']))." wrote";
+            $title = htmlspecialchars(trim($params['name']), ENT_QUOTES)." wrote";
             if (isset($params['date'])) {
-                $title .= " on ".htmlspecialchars(trim($params['date']));
+                $title .= " on ".htmlspecialchars(trim($params['date']), ENT_QUOTES);
             }
             $title .= ":";
             if (isset($params['url'])) {
                 $url = trim($params['url']);
                 if ($bbcode->isValidURL($url)) {
-                    $title = "<a href=\"".htmlspecialchars($params['url'])."\">".$title."</a>";
+                    $title = "<a href=\"".htmlspecialchars($params['url'], ENT_QUOTES)."\">".$title."</a>";
                 }
             }
         } elseif (!is_string($default)) {
             $title = "Quote:";
         } else {
-            $title = htmlspecialchars(trim($default))." wrote:";
+            $title = htmlspecialchars(trim($default), ENT_QUOTES)." wrote:";
         }
 
         return $bbcode->fillTemplate($bbcode->getQuoteTemplate(), array("title" => $title, "content" => $content));

--- a/tests/ConformanceTest.php
+++ b/tests/ConformanceTest.php
@@ -130,6 +130,16 @@ class ConformanceTest extends TestCase {
                 'escape_content' => false,
             ]],
             [[
+                'descr' => "Single quotes in tags are NOT considered special characters.",
+                'bbcode' => "[wiki='foo' title='bar']",
+                'html' => "<a href=\"/?page=foo\" class=\"bbcode_wiki\">bar</a>",
+            ]],
+            [[
+                'descr' => "Double quotes in tags are NOT considered special characters.",
+                'bbcode' => "[wiki=\"foo\" title=\"bar\"]",
+                'html' => "<a href=\"/?page=foo\" class=\"bbcode_wiki\">bar</a>",
+            ]],
+            [[
                 'descr' => ":-) produces a smiley <img> element.",
                 'bbcode' => "This is a test of the emergency broadcasting system :-)",
                 'regex' => <<<'REGEX'
@@ -384,8 +394,13 @@ BBCODE
                 'html' => "This is a test of the <span style=\"font-family:'Times New Roman'\">emergency broadcasting system</span>.",
             ]],
             [[
-                'descr' => "[font=\"Courier New\"] gets correctly converted (quoted default value).",
+                'descr' => "[font=\"Courier New\"] gets correctly converted (double quoted default value).",
                 'bbcode' => "This is a test of the [font=\"Courier New\"]emergency broadcasting system[/font].",
+                'html' => "This is a test of the <span style=\"font-family:'Courier New'\">emergency broadcasting system</span>.",
+            ]],
+            [[
+                'descr' => "[font='Courier New'] gets correctly converted (single quoted default value).",
+                'bbcode' => "This is a test of the [font='Courier New']emergency broadcasting system[/font].",
                 'html' => "This is a test of the <span style=\"font-family:'Courier New'\">emergency broadcasting system</span>.",
             ]],
             [[

--- a/tests/ConformanceTest.php
+++ b/tests/ConformanceTest.php
@@ -52,14 +52,14 @@ class ConformanceTest extends TestCase {
                 'html' => "This is [/ a tag.",
             ]],
             [[
-                'descr' => "Broken [ tags before [b]real tags[/b] don't break the real tags.",
-                'bbcode' => "Broken [ tags before [b]real tags[/b] don't break the real tags.",
-                'html' => "Broken [ tags before <b>real tags</b> don't break the real tags.",
+                'descr' => "Broken [ tags before [b]real tags[/b] do not break the real tags.",
+                'bbcode' => "Broken [ tags before [b]real tags[/b] do not break the real tags.",
+                'html' => "Broken [ tags before <b>real tags</b> do not break the real tags.",
             ]],
             [[
-                'descr' => "Broken [tags before [b]real tags[/b] don't break the real tags.",
-                'bbcode' => "Broken [tags before [b]real tags[/b] don't break the real tags.",
-                'html' => "Broken [tags before <b>real tags</b> don't break the real tags.",
+                'descr' => "Broken [tags before [b]real tags[/b] do not break the real tags.",
+                'bbcode' => "Broken [tags before [b]real tags[/b] do not break the real tags.",
+                'html' => "Broken [tags before <b>real tags</b> do not break the real tags.",
             ]],
             [[
                 'descr' => "[i][b]Mis-ordered nesting[/i][/b] gets fixed.",
@@ -119,9 +119,15 @@ class ConformanceTest extends TestCase {
     public function provideSpecialCharacterTests() {
         $result = [
             [[
-                'descr' => "& and < and > and \" get replaced with HTML-safe equivalents.",
+                'descr' => "& and < and > and \" and ' get replaced with HTML-safe equivalents.",
                 'bbcode' => "This <woo!> &\"yeah!\" 'sizzle'",
-                'html' => "This &lt;woo!&gt; &amp;&quot;yeah!&quot; 'sizzle'",
+                'html' => "This &lt;woo!&gt; &amp;&quot;yeah!&quot; &#039;sizzle&#039;",
+            ]],
+            [[
+                'descr' => "& and < and > and \" and ' do NOT get replaced with HTML-safe equivalents if setEscapeContent(false).",
+                'bbcode' => "This <woo!> &\"yeah!\" 'sizzle'",
+                'html' => "This <woo!> &\"yeah!\" 'sizzle'",
+                'escape_content' => false,
             ]],
             [[
                 'descr' => ":-) produces a smiley <img> element.",
@@ -189,7 +195,7 @@ REGEX
             [[
                 'descr' => "['] comments may *not* contain newlines.",
                 'bbcode' => "This is a test of the [' emergency\n\rbroadcasting] system.",
-                'html' => "This is a test of the [' emergency<br>\nbroadcasting] system.",
+                'html' => "This is a test of the [&#039; emergency<br>\nbroadcasting] system.",
             ]],
             [[
                 'descr' => "[!-- --] produces a comment.",
@@ -425,7 +431,7 @@ BBCODE
             [[
                 'descr' => "[spoiler] gets converted.",
                 'bbcode' => "Ssh, don't tell, but [spoiler]Darth is Luke's father[/spoiler]!",
-                'html' => "Ssh, don't tell, but <span class=\"bbcode_spoiler\">Darth is Luke's father</span>!",
+                'html' => "Ssh, don&#039;t tell, but <span class=\"bbcode_spoiler\">Darth is Luke&#039;s father</span>!",
             ]],
             [[
                 'descr' => "[acronym] gets converted.",
@@ -721,7 +727,7 @@ BBCODE
             [[
                 'descr' => "The [[wiki]] special tag does not convert [a-zA-Z0-9'\".:_-].",
                 'bbcode' => "This is a test of the [[\"Ab1cd'Ef2gh_Ij3kl.,Mn4op:Qr9st-Uv0wx\"]] tag.",
-                'html' => "This is a test of the <a href=\"/?page=%22Ab1cd%27Ef2gh_Ij3kl.%2CMn4op%3AQr9st_Uv0wx%22\" class=\"bbcode_wiki\">&quot;Ab1cd'Ef2gh_Ij3kl.,Mn4op:Qr9st-Uv0wx&quot;</a> tag.",
+                'html' => "This is a test of the <a href=\"/?page=%22Ab1cd%27Ef2gh_Ij3kl.%2CMn4op%3AQr9st_Uv0wx%22\" class=\"bbcode_wiki\">&quot;Ab1cd&#039;Ef2gh_Ij3kl.,Mn4op:Qr9st-Uv0wx&quot;</a> tag.",
             ]],
             [[
                 'descr' => "The [[wiki]] special tag can contain spaces.",
@@ -761,23 +767,23 @@ BBCODE
         $result = [
             [[
                 'descr' => "[img] produces an image.",
-                'bbcode' => "This is Google's logo: [img]http://www.google.com/intl/en_ALL/images/logo.gif[/img].",
-                'html' => "This is Google's logo: <img src=\"http://www.google.com/intl/en_ALL/images/logo.gif\" alt=\"logo.gif\" class=\"bbcode_img\" />.",
+                'bbcode' => "This is the Google logo: [img]http://www.google.com/intl/en_ALL/images/logo.gif[/img].",
+                'html' => "This is the Google logo: <img src=\"http://www.google.com/intl/en_ALL/images/logo.gif\" alt=\"logo.gif\" class=\"bbcode_img\" />.",
             ]],
             [[
                 'descr' => "[img] disallows a javascript: URL.",
-                'bbcode' => "This is Google's logo: [img]javascript:alert()[/img].",
-                'html' => "This is Google's logo: [img]javascript:alert()[/img].",
+                'bbcode' => "This is the Google logo: [img]javascript:alert()[/img].",
+                'html' => "This is the Google logo: [img]javascript:alert()[/img].",
             ]],
             [[
                 'descr' => "[img] disallows a URL with an unknown protocol type.",
-                'bbcode' => "This is Google's logo: [img]foobar:bar.jpg[/img].",
-                'html' => "This is Google's logo: [img]foobar:bar.jpg[/img].",
+                'bbcode' => "This is the Google logo: [img]foobar:bar.jpg[/img].",
+                'html' => "This is the Google logo: [img]foobar:bar.jpg[/img].",
             ]],
             [[
                 'descr' => "[img] disallows HTML content.",
-                'bbcode' => "This is Google's logo: [img]<a href='javascript:alert(\"foo\")'>click me</a>[/img].",
-                'html' => "This is Google's logo: [img]&lt;a href='javascript:alert(&quot;foo&quot;)'&gt;click me&lt;/a&gt;[/img].",
+                'bbcode' => "This is the Google logo: [img]<a href='javascript:alert(\"foo\")'>click me</a>[/img].",
+                'html' => "This is the Google logo: [img]&lt;a href=&#039;javascript:alert(&quot;foo&quot;)&#039;&gt;click me&lt;/a&gt;[/img].",
             ]],
             [[
                 'descr' => "[img] can produce a local image.",
@@ -865,7 +871,7 @@ BBCODE
                     . "\n<div class=\"bbcode_code\">\n"
                     . "<div class=\"bbcode_code_head\">Code:</div>\n"
                     . "<div class=\"bbcode_code_body\" style=\"white-space:pre\">A [b]and[/b] &amp; &lt;woo&gt;!\n"
-                    . "\tAnd a ['hey'] and a [/nonny] and a ho ho ho!</div>\n"
+                    . "\tAnd a [&#039;hey&#039;] and a [/nonny] and a ho ho ho!</div>\n"
                     . "</div>\n"
                     . "Also not code.",
             ]],
@@ -880,7 +886,7 @@ BBCODE
                 'html' => "Not code."
                     . "\n<div class=\"bbcode_code\">\n"
                     . "<div class=\"bbcode_code_head\">Code:</div>\n"
-                    . "<div class=\"bbcode_code_body\" style=\"white-space:pre\">\$foo['bar'] = 42;\n"
+                    . "<div class=\"bbcode_code_body\" style=\"white-space:pre\">\$foo[&#039;bar&#039;] = 42;\n"
                     . "if (\$foo[&quot;bar&quot;] &lt; 42) \$foo[] = 0;</div>\n"
                     . "</div>\n"
                     . "Also not code.<br>\n",
@@ -1039,8 +1045,8 @@ BBCODE
             ]],
             [[
                 'descr' => "[nextcol] doesn't do anything outside a [columns] block.",
-                'bbcode' => "Here's some text.[nextcol]\nHere's some more.\n",
-                'html' => "Here's some text.[nextcol]<br>\nHere's some more.<br>\n",
+                'bbcode' => "Here is some text.[nextcol]\nHere is some more.\n",
+                'html' => "Here is some text.[nextcol]<br>\nHere is some more.<br>\n",
             ]],
             [[
                 'descr' => "Bad column misuse doesn't break layouts.",
@@ -1175,6 +1181,7 @@ BBCODE
         $bbcode->setURLTargetable($test['urltarget'] == true);
         $bbcode->setURLTarget($test['urlforcetarget']);
         $bbcode->setPlainMode($test['plainmode']);
+        $bbcode->setEscapeContent($test['escape_content'] ?? true);
 
         if ($test['tag_marker'] === '<') {
             $bbcode->setTagMarker('<');


### PR DESCRIPTION
**NOTICE**: This PR introduces a change in behavior. We may want to carefully consider our options before merging, as there are compelling reasons for each possible solution to this issue. Thank you!

In PHP 8.1, the default flags for `htmlspecialchars` have changed so
that single quotes are now escaped (for security reasons). As a result,
we must explicitly pass flags to `htmlspecialchars` in order for NBBC
to have consistent behavior between pre-8.1 and post-8.1 PHP versions.

If we wanted to retain the pre-8.1 behavior, then we would use the
ENT_COMPAT flag. However, since it seems that the PHP devs made this
change for a good reason, it's likely worth changing the behavior of
NBBC as well. Therefore, this PR chooses to pass ENT_QUOTES instead
(the same as ENT_COMPAT, except also escapes single quotes).

Note that ENT_QUOTES is not quite the 8.1 default for htmlspecialchars,
which also includes ENT_SUBSTITUTE (for security reasons again). This
begins to be a bit cumbersome, but could be included for full parity
with PHP 8.1, if desired.

Added CircleCI tests for PHP 8.1, which now pass. Tests were updated to
reflect single quotes being escaped as `&#039;`, and also added a test
case for `setEscapeContent(false)`, which was previously untested.

This site has a thorough summary of the change to `htmlspecialchars`:
https://php.watch/versions/8.1/html-entity-default-value-changes