### PR TITLE
Make lexer and stack public properties of BBCode

### DIFF
--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -221,8 +221,8 @@ class BBCode {
     public $debug;   // Enable debugging mode
     protected $max_smileys; // Maximum number of smileys that can be used in parse
     protected $escape_content; // Encode HTML. POTENTIALLY DANGEROUS IF DISABLED. ONLY DISABLE IF YOU KNOW WHAT YOURE DOING.
-    protected $lexer; // BBCodeLexer created when calling parse
-    protected $stack; // The token stack is used to perform a document-tree walk
+    public $lexer; // BBCodeLexer created when calling parse
+    public $stack; // The token stack is used to perform a document-tree walk
 
     /**
      * Initialize a new instance of the {@link BBCode} class.


### PR DESCRIPTION
This fixes a backwards compatibility break that was unintentionally introduced in #31.

See https://github.com/vanilla/nbbc/pull/31#issuecomment-1482046147 for details about the use case.