### PR TITLE
Fix PHP 8.4 deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ["7.4", "8.0", "8.1", "8.2"]
+        php-version: ["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]
     steps:
       - uses: actions/checkout@v3
       - name: Installing PHP ${{ matrix.php-version }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 NBBC is a high-speed, extensible, easy-to-use validating BBCode parser that accepts BBCode as input and generates XHTML 1.0 Transitional-compliant markup as its output no matter how mangled the input. It includes built-in support for most common BBCode, as well as external-wiki support, image-library support, a standard library of smileys (emoticons), and via its powerful API it can even be transformed into a validating HTML parser!
 
-NBBC is well-tested, with its output validated against a unit-test suite with over a hundred different tests. It is written entirely in PHP, using clean, namespace-friendly, object-oriented code, and it is compatible both PHP 5.4 and up.
+NBBC is well-tested, with its output validated against a unit-test suite with over a hundred different tests. It is written entirely in PHP, using clean, namespace-friendly, object-oriented code, and it is compatible with PHP 7.1 and up.
 
 While flexible and powerful, NBBC is also designed to be an easy to use, and is an easy drop-in replacement for most existing BBCode-parsing solutions. In many cases, it can be implemented in your own projects with only two or three lines of code. Only a single PHP source file is necessary in your projects, a compact, optimized file that is automatically generated from the included heavily-commented original PHP source files.
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.4.0"
+		"php": ">=7.1.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8"

--- a/doc/install_req.html
+++ b/doc/install_req.html
@@ -21,7 +21,7 @@
 <p>To use NBBC in your programs, you will need to have the following:</p>
 
 <ul>
-<li>A web server running PHP 4.0.5 or higher, or PHP 5.0 or higher.</li>
+<li>A web server running PHP 7.1 or higher.</li>
 <li>Some PHP programming skills (say, skill level 2, where 1 is "newbie" and 5 is "guru").</li>
 </ul>
 

--- a/doc/intro_over.html
+++ b/doc/intro_over.html
@@ -24,7 +24,7 @@
 Copyright &copy; 2008-10, the Phantom Inker.  All rights reserved.</p>
 
 <p>The New BBCode Parser (NBBC) is a fully-validating, high-speed, extensible parser
-for the BBCode document language, written in PHP, compatible with PHP 4.0.5+ and PHP 5.
+for the BBCode document language, written in PHP, compatible with PHP 7.1+.
 It converts BBCode input into HTML output, and can guarantee that the output will be
 fully conformant to the XHTML 1.0 Strict standard no matter how badly-mangled the BBCode
 input is.</p>

--- a/doc/src/install_req.tpl
+++ b/doc/src/install_req.tpl
@@ -2,7 +2,7 @@
 <p>To use NBBC in your programs, you will need to have the following:</p>
 
 <ul>
-<li>A web server running PHP 4.0.5 or higher, or PHP 5.0 or higher.</li>
+<li>A web server running PHP 7.1 or higher.</li>
 <li>Some PHP programming skills (say, skill level 2, where 1 is "newbie" and 5 is "guru").</li>
 </ul>
 

--- a/doc/src/intro_over.tpl
+++ b/doc/src/intro_over.tpl
@@ -5,7 +5,7 @@
 Copyright &copy; 2008-10, the Phantom Inker.  All rights reserved.</p>
 
 <p>The New BBCode Parser (NBBC) is a fully-validating, high-speed, extensible parser
-for the BBCode document language, written in PHP, compatible with PHP 4.0.5+ and PHP 5.
+for the BBCode document language, written in PHP, compatible with PHP 7.1+.
 It converts BBCode input into HTML output, and can guarantee that the output will be
 fully conformant to the XHTML 1.0 Strict standard no matter how badly-mangled the BBCode
 input is.</p>

--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -229,7 +229,7 @@ class BBCode {
      *
      * @param BBCodeLibrary|null $library
      */
-    public function __construct(BBCodeLibrary $library = null) {
+    public function __construct(?BBCodeLibrary $library = null) {
         $this->defaults = isset($library) ? $library : new BBCodeLibrary();
         $this->tag_rules = $this->defaults->default_tag_rules;
         $this->smileys = $this->defaults->default_smileys;


### PR DESCRIPTION
Implicitly nullable parameters (i.e. those accepting null without a null typehint) are deprecated in PHP 8.4. Marking `$library` as explicitly nullable fixes the following deprecation warning:

> Deprecated: Nbbc\BBCode::__construct(): Implicitly marking parameter
> $library as nullable is deprecated, the explicit nullable type must be
> used instead

Explicitly nullable types were not added until PHP 7.1, so the minimum requirement is raised from 5.6 (which reached EOL in 2017) to 7.1 (which was released in 2016). Documentation has been updated accordingly.

Added PHP 8.3 and 8.4 to the GitHub Actions test matrix.